### PR TITLE
next

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,9 @@ store.on('clear', function() {})
 store.one(eventName, eventHandlerFunction)
 store.off(eventName, eventHandlerFunction)
 
+// implicit id prefixes for methods and events
+store.withIdPrefix(prefix)
+
 // original PouchDB (http://pouchdb.com/api.html) instance used for the store
 store.db
 ```

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ var revokeAccess = require('./store/revoke')
 var replicate = require('./store/replicate')
 var cancelReplication = require('./store/cancel-replication')
 
+var cache = require('./utils/cache')
 var replicationIdPrefix = require('./utils/to-replication-id').prefix
 var toCouchDbUrl = require('./utils/pouchdb-options-to-couchdb-url')
 
@@ -81,7 +82,8 @@ function StoreAPIFactory (PouchDB) {
     usesHttpAdapter: usesHttpAdapter,
     replicationsReady: replicationsReady,
     replicationsMap: replicationsMap,
-    emitter: new EventEmitter()
+    emitter: new EventEmitter(),
+    cache: cache(stateStore)
   }
   var Store = {}
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "lodash": "^4.17.3",
     "mkdirp": "^0.5.1",
-    "pouchdb-hoodie-api": "^1.6.4",
+    "pouchdb-hoodie-api": "^2.0.0",
     "request": "^2.79.0",
     "to-id": "^1.0.5"
   },

--- a/store/cancel-replication.js
+++ b/store/cancel-replication.js
@@ -14,12 +14,7 @@ function cancelReplication (state, source, target, options) {
       return
     }
 
-    state.metaDb.get(id)
-
-    .then(function (doc) {
-      doc._deleted = true
-      return state.metaDb.put(doc)
-    })
+    state.stateStore.remove(id)
 
     .then(function () {
       delete state.replicationsMap[id]

--- a/store/create.js
+++ b/store/create.js
@@ -40,7 +40,7 @@ function createStore (state, name, options) {
 
     return state.stateStore.add(doc)
 
-    .then(function () {
+    .then(function (doc) {
       if (!state.usesHttpAdapter) {
         var db = new state.PouchDB(name)
         return db.info()
@@ -67,6 +67,8 @@ function createStore (state, name, options) {
           throw error
         })
       }
+
+      state.cache.set(doc)
 
       return new state.PouchDB(name).info().then(function () {
         var options = {

--- a/store/create.js
+++ b/store/create.js
@@ -38,7 +38,7 @@ function createStore (state, name, options) {
       })
     }
 
-    return state.metaDb.put(doc)
+    return state.stateStore.add(doc)
 
     .then(function () {
       if (!state.usesHttpAdapter) {

--- a/store/destroy.js
+++ b/store/destroy.js
@@ -3,7 +3,7 @@ module.exports = destroyStore
 var getDocOrFalse = require('../utils/get-doc-or-false')
 
 function destroyStore (state, name) {
-  return getDocOrFalse(state.stateStore, name)
+  return getDocOrFalse(state, name)
 
   .then(function (doc) {
     if (doc === false) {
@@ -14,7 +14,8 @@ function destroyStore (state, name) {
     return state.stateStore.update(doc)
   })
 
-  .then(function () {
+  .then(function (doc) {
+    state.cache.unset(doc._id)
     return new state.PouchDB(name).destroy()
   })
 

--- a/store/destroy.js
+++ b/store/destroy.js
@@ -3,7 +3,7 @@ module.exports = destroyStore
 var getDocOrFalse = require('../utils/get-doc-or-false')
 
 function destroyStore (state, name) {
-  return getDocOrFalse(state.metaDb, name)
+  return getDocOrFalse(state.stateStore, name)
 
   .then(function (doc) {
     if (doc === false) {
@@ -11,7 +11,7 @@ function destroyStore (state, name) {
     }
 
     doc._deleted = true
-    return state.metaDb.put(doc)
+    return state.stateStore.update(doc)
   })
 
   .then(function () {

--- a/store/exists.js
+++ b/store/exists.js
@@ -3,7 +3,7 @@ module.exports = storeExists
 var getDocOrFalse = require('../utils/get-doc-or-false')
 
 function storeExists (state, name) {
-  return getDocOrFalse(state.metaDb, name)
+  return getDocOrFalse(state.stateStore, name)
 
   .then(function (result) {
     return !!result

--- a/store/exists.js
+++ b/store/exists.js
@@ -3,7 +3,7 @@ module.exports = storeExists
 var getDocOrFalse = require('../utils/get-doc-or-false')
 
 function storeExists (state, name) {
-  return getDocOrFalse(state.stateStore, name)
+  return getDocOrFalse(state, name)
 
   .then(function (result) {
     return !!result

--- a/store/grant.js
+++ b/store/grant.js
@@ -7,13 +7,9 @@ var getRoleOption = require('../utils/get-role-option')
 var toDbId = require('../utils/to-db-id')
 
 function grantAccess (state, name, options) {
-  return state.metaDb.get(toDbId(name))
-
-  .then(function (doc) {
+  return state.stateStore.update(toDbId(name), function (doc) {
     _.concat(options.access).forEach(function (privilege) {
       addRolePrivilege(doc.access, getRoleOption(options), privilege)
     })
-
-    return state.metaDb.put(doc)
   })
 }

--- a/store/grant.js
+++ b/store/grant.js
@@ -12,4 +12,8 @@ function grantAccess (state, name, options) {
       addRolePrivilege(doc.access, getRoleOption(options), privilege)
     })
   })
+
+  .then(function (doc) {
+    return state.cache.set(doc)
+  })
 }

--- a/store/has-access.js
+++ b/store/has-access.js
@@ -7,7 +7,7 @@ var hasRolePrivilege = require('../utils/has-role-privilege')
 var toDbId = require('../utils/to-db-id')
 
 function hasAccess (state, name, options) {
-  return state.metaDb.get(toDbId(name))
+  return state.stateStore.find(toDbId(name))
 
   .then(function (doc) {
     var privileges = _.concat(options.access)

--- a/store/has-access.js
+++ b/store/has-access.js
@@ -7,7 +7,7 @@ var hasRolePrivilege = require('../utils/has-role-privilege')
 var toDbId = require('../utils/to-db-id')
 
 function hasAccess (state, name, options) {
-  return state.stateStore.find(toDbId(name))
+  return state.cache.get(toDbId(name))
 
   .then(function (doc) {
     var privileges = _.concat(options.access)

--- a/store/replicate.js
+++ b/store/replicate.js
@@ -31,7 +31,7 @@ function replicate (state, source, target, options) {
 
   var id = toReplicationId(source, target, options)
 
-  return state.metaDb.put({
+  return state.stateStore.add({
     _id: id,
     source: source,
     target: target,

--- a/store/revoke.js
+++ b/store/revoke.js
@@ -7,13 +7,9 @@ var removeRolePrivilege = require('../utils/remove-role-privilege')
 var toDbId = require('../utils/to-db-id')
 
 function revokeAccess (state, name, options) {
-  return state.metaDb.get(toDbId(name))
-
-  .then(function (doc) {
+  return state.stateStore.update(toDbId(name), function (doc) {
     _.concat(options.access).forEach(function (privilege) {
       removeRolePrivilege(doc.access, getRoleOption(options), privilege)
     })
-
-    return state.metaDb.put(doc)
   })
 }

--- a/store/revoke.js
+++ b/store/revoke.js
@@ -12,4 +12,8 @@ function revokeAccess (state, name, options) {
       removeRolePrivilege(doc.access, getRoleOption(options), privilege)
     })
   })
+
+  .then(function (doc) {
+    return state.cache.set(doc)
+  })
 }

--- a/test/integration/replication-test.js
+++ b/test/integration/replication-test.js
@@ -45,8 +45,8 @@ test('Store', function (group) {
 
     .then(function () {
       // simulate bootstrapping of live replications on restart
-      var metaDb = new PouchDB('hoodie-store')
-      return metaDb.put({
+      var stateDb = new PouchDB('hoodie-store')
+      return stateDb.put({
         _id: 'replication_db2_db1',
         source: 'db2',
         target: 'db1',

--- a/test/integration/replication-test.js
+++ b/test/integration/replication-test.js
@@ -22,7 +22,7 @@ test('Store', function (group) {
     })
 
     .then(function (store) {
-      return store.add({id: 'foo'})
+      return store.add({_id: 'foo'})
     })
 
     .then(function () {
@@ -63,7 +63,7 @@ test('Store', function (group) {
     })
 
     .then(function (store) {
-      return store.add({id: 'bar'})
+      return store.add({_id: 'bar'})
     })
 
     .then(function () {
@@ -93,7 +93,7 @@ test('Store', function (group) {
     })
 
     .then(function (store) {
-      return store.add({id: 'baz'})
+      return store.add({_id: 'baz'})
     })
 
     .then(function () {

--- a/test/integration/store-test.js
+++ b/test/integration/store-test.js
@@ -4,46 +4,46 @@ var test = require('tap').test
 var StoreAPIFactory = require('../..')
 
 test('Store', function (group) {
-  group.test('API', function (t) {
-    var Store = StoreAPIFactory(PouchDB)
-
-    t.is(typeof Store.adapter, 'string', 'Store.adapter')
-    t.is(typeof Store.create, 'function', 'Store.create()')
-    t.is(typeof Store.destroy, 'function', 'Store.destroy()')
-    t.is(typeof Store.exists, 'function', 'Store.exists()')
-    t.is(typeof Store.open, 'function', 'Store.open()')
-    t.is(typeof Store.grant, 'function', 'Store.grant()')
-    t.is(typeof Store.hasAccess, 'function', 'Store.hasAccess()')
-    t.is(typeof Store.revoke, 'function', 'Store.revoke()')
-    t.is(typeof Store.replicate, 'function', 'Store.replicate()')
-    t.is(typeof Store.cancelReplication, 'function', 'Store.cancelReplication()')
-    t.is(typeof Store.on, 'function', 'Store.on()')
-    t.is(typeof Store.one, 'function', 'Store.one()')
-    t.is(typeof Store.off, 'function', 'Store.off()')
-
-    t.end()
-  })
-  group.test('Store.open resolves with store instance', function (t) {
-    t.plan(2)
-
-    var Store = StoreAPIFactory(PouchDB)
-
-    Store.create('dbname')
-
-    .then(function () {
-      return Store.open('dbname')
-    })
-
-    .then(function (store) {
-      t.is(typeof store.add, 'function', 'returns Store Instance')
-
-      return Store.destroy('dbname')
-    })
-
-    .then(t.ok)
-
-    .catch(t.error)
-  })
+  // group.test('API', function (t) {
+  //   var Store = StoreAPIFactory(PouchDB)
+  //
+  //   t.is(typeof Store.adapter, 'string', 'Store.adapter')
+  //   t.is(typeof Store.create, 'function', 'Store.create()')
+  //   t.is(typeof Store.destroy, 'function', 'Store.destroy()')
+  //   t.is(typeof Store.exists, 'function', 'Store.exists()')
+  //   t.is(typeof Store.open, 'function', 'Store.open()')
+  //   t.is(typeof Store.grant, 'function', 'Store.grant()')
+  //   t.is(typeof Store.hasAccess, 'function', 'Store.hasAccess()')
+  //   t.is(typeof Store.revoke, 'function', 'Store.revoke()')
+  //   t.is(typeof Store.replicate, 'function', 'Store.replicate()')
+  //   t.is(typeof Store.cancelReplication, 'function', 'Store.cancelReplication()')
+  //   t.is(typeof Store.on, 'function', 'Store.on()')
+  //   t.is(typeof Store.one, 'function', 'Store.one()')
+  //   t.is(typeof Store.off, 'function', 'Store.off()')
+  //
+  //   t.end()
+  // })
+  // group.test('Store.open resolves with store instance', function (t) {
+  //   t.plan(2)
+  //
+  //   var Store = StoreAPIFactory(PouchDB)
+  //
+  //   Store.create('dbname')
+  //
+  //   .then(function () {
+  //     return Store.open('dbname')
+  //   })
+  //
+  //   .then(function (store) {
+  //     t.is(typeof store.add, 'function', 'returns Store Instance')
+  //
+  //     return Store.destroy('dbname')
+  //   })
+  //
+  //   .then(t.ok)
+  //
+  //   .catch(t.error)
+  // })
 
   group.test('create / open / destroy walkthrough', function (t) {
     t.plan(8)
@@ -80,7 +80,7 @@ test('Store', function (group) {
 
     .then(function (doc) {
       var db = new PouchDB('dbname')
-      return db.get(doc.id)
+      return db.get(doc._id)
     })
 
     .then(function (doc) {

--- a/test/integration/store-test.js
+++ b/test/integration/store-test.js
@@ -4,46 +4,46 @@ var test = require('tap').test
 var StoreAPIFactory = require('../..')
 
 test('Store', function (group) {
-  // group.test('API', function (t) {
-  //   var Store = StoreAPIFactory(PouchDB)
-  //
-  //   t.is(typeof Store.adapter, 'string', 'Store.adapter')
-  //   t.is(typeof Store.create, 'function', 'Store.create()')
-  //   t.is(typeof Store.destroy, 'function', 'Store.destroy()')
-  //   t.is(typeof Store.exists, 'function', 'Store.exists()')
-  //   t.is(typeof Store.open, 'function', 'Store.open()')
-  //   t.is(typeof Store.grant, 'function', 'Store.grant()')
-  //   t.is(typeof Store.hasAccess, 'function', 'Store.hasAccess()')
-  //   t.is(typeof Store.revoke, 'function', 'Store.revoke()')
-  //   t.is(typeof Store.replicate, 'function', 'Store.replicate()')
-  //   t.is(typeof Store.cancelReplication, 'function', 'Store.cancelReplication()')
-  //   t.is(typeof Store.on, 'function', 'Store.on()')
-  //   t.is(typeof Store.one, 'function', 'Store.one()')
-  //   t.is(typeof Store.off, 'function', 'Store.off()')
-  //
-  //   t.end()
-  // })
-  // group.test('Store.open resolves with store instance', function (t) {
-  //   t.plan(2)
-  //
-  //   var Store = StoreAPIFactory(PouchDB)
-  //
-  //   Store.create('dbname')
-  //
-  //   .then(function () {
-  //     return Store.open('dbname')
-  //   })
-  //
-  //   .then(function (store) {
-  //     t.is(typeof store.add, 'function', 'returns Store Instance')
-  //
-  //     return Store.destroy('dbname')
-  //   })
-  //
-  //   .then(t.ok)
-  //
-  //   .catch(t.error)
-  // })
+  group.test('API', function (t) {
+    var Store = StoreAPIFactory(PouchDB)
+
+    t.is(typeof Store.adapter, 'string', 'Store.adapter')
+    t.is(typeof Store.create, 'function', 'Store.create()')
+    t.is(typeof Store.destroy, 'function', 'Store.destroy()')
+    t.is(typeof Store.exists, 'function', 'Store.exists()')
+    t.is(typeof Store.open, 'function', 'Store.open()')
+    t.is(typeof Store.grant, 'function', 'Store.grant()')
+    t.is(typeof Store.hasAccess, 'function', 'Store.hasAccess()')
+    t.is(typeof Store.revoke, 'function', 'Store.revoke()')
+    t.is(typeof Store.replicate, 'function', 'Store.replicate()')
+    t.is(typeof Store.cancelReplication, 'function', 'Store.cancelReplication()')
+    t.is(typeof Store.on, 'function', 'Store.on()')
+    t.is(typeof Store.one, 'function', 'Store.one()')
+    t.is(typeof Store.off, 'function', 'Store.off()')
+
+    t.end()
+  })
+  group.test('Store.open resolves with store instance', function (t) {
+    t.plan(2)
+
+    var Store = StoreAPIFactory(PouchDB)
+
+    Store.create('dbname')
+
+    .then(function () {
+      return Store.open('dbname')
+    })
+
+    .then(function (store) {
+      t.is(typeof store.add, 'function', 'returns Store Instance')
+
+      return Store.destroy('dbname')
+    })
+
+    .then(t.ok)
+
+    .catch(t.error)
+  })
 
   group.test('create / open / destroy walkthrough', function (t) {
     t.plan(8)

--- a/test/unit/factory-test.js
+++ b/test/unit/factory-test.js
@@ -4,8 +4,19 @@ var StoreAPIFactory = require('../..')
 
 var PouchDBMock = function () {
   return {
-    allDocs: function () {
-      return Promise.resolve({rows: []})
+    hoodieApi: function () {
+      return {
+        db: {
+          __opts: {}
+        },
+        withIdPrefix: function () {
+          return {
+            findAll: function () {
+              return Promise.resolve([])
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/test/unit/factory-test.js
+++ b/test/unit/factory-test.js
@@ -7,7 +7,12 @@ var PouchDBMock = function () {
     hoodieApi: function () {
       return {
         db: {
-          __opts: {}
+          __opts: {},
+          changes: function () {
+            return {
+              on: function () {}
+            }
+          }
         },
         withIdPrefix: function () {
           return {

--- a/utils/cache.js
+++ b/utils/cache.js
@@ -1,0 +1,42 @@
+module.exports = cache
+
+function cache (stateStore) {
+  var memory = {}
+
+  stateStore.db.changes({
+    since: 'now',
+    live: true,
+    include_docs: true
+  }).on('change', function (change) {
+    if (change.deleted) {
+      delete memory[change.id]
+      return
+    }
+    memory[change.id] = change.doc
+  })
+
+  return {
+    get: function (key) {
+      if (memory[key]) {
+        return Promise.resolve(memory[key])
+      }
+
+      return stateStore.find(key)
+
+      .then(function (doc) {
+        memory[key] = doc
+        return doc
+      })
+    },
+
+    set: function (doc) {
+      memory[doc._id] = doc
+      return Promise.resolve(memory[doc._id])
+    },
+
+    unset: function (key) {
+      delete memory[key]
+      return Promise.resolve()
+    }
+  }
+}

--- a/utils/get-doc-or-false.js
+++ b/utils/get-doc-or-false.js
@@ -2,8 +2,8 @@ module.exports = getDocOrFalse
 
 var toDbId = require('./to-db-id')
 
-function getDocOrFalse (stateStore, name) {
-  return stateStore.find(toDbId(name))
+function getDocOrFalse (state, name) {
+  return state.cache.get(toDbId(name))
 
   .catch(function (error) {
     if (error.status === 404) {

--- a/utils/get-doc-or-false.js
+++ b/utils/get-doc-or-false.js
@@ -2,8 +2,8 @@ module.exports = getDocOrFalse
 
 var toDbId = require('./to-db-id')
 
-function getDocOrFalse (metaDb, name) {
-  return metaDb.get(toDbId(name))
+function getDocOrFalse (stateStore, name) {
+  return stateStore.find(toDbId(name))
 
   .catch(function (error) {
     if (error.status === 404) {


### PR DESCRIPTION
- [x] updates `pouchdb-hoodie-api` to v2 which includes several breaking changes (6eab6b911270e5628de14266102fd745030e3bd5)
- [x] cache accessed databases in-memory and keep it updated with a `.changes()` feed (see https://github.com/hoodiehq/hoodie-server/issues/537)